### PR TITLE
fix compilation error under linux

### DIFF
--- a/src/storage/ButtonMapTranslator.cpp
+++ b/src/storage/ButtonMapTranslator.cpp
@@ -74,7 +74,7 @@ ADDON::DriverPrimitive ButtonMapTranslator::ToDriverPrimitive(const std::string&
 
     if (bIsButton)
     {
-      primitive = ADDON::DriverPrimitive(std::atoi(strPrimitive.c_str()));
+      primitive = ADDON::DriverPrimitive::CreateButton(std::atoi(strPrimitive.c_str()));
     }
     else if (bIsHat)
     {


### PR DESCRIPTION
I couldn't compile under linux:

```
/home/a1rwulf/kodi/include/kodi/kodi_peripheral_utils.hpp: In static member function ‘static ADDON::DriverPrimitive JOYSTICK::ButtonMapTranslator::ToDriverPrimitive(const string&)’:
/home/a1rwulf/kodi/include/kodi/kodi_peripheral_utils.hpp:376:5: error: ‘ADDON::DriverPrimitive::DriverPrimitive(JOYSTICK_DRIVER_PRIMITIVE_TYPE, unsigned int)’ is protected
     DriverPrimitive(JOYSTICK_DRIVER_PRIMITIVE_TYPE type, unsigned int driverIndex) :
     ^
/home/a1rwulf/devel/kodi-game/peripheral.joystick/src/storage/ButtonMapTranslator.cpp:77:112: error: within this context
       primitive = ADDON::DriverPrimitive(JOYSTICK_DRIVER_PRIMITIVE_TYPE_BUTTON, std::atoi(strPrimitive.c_str()));
```

This PR fixes my compilation issue, don't know if I'm the only one that experienced this.
